### PR TITLE
fix zte e8820s wan interface not working

### DIFF
--- a/target/linux/ramips/dts/mt7621_zte_e8820s.dts
+++ b/target/linux/ramips/dts/mt7621_zte_e8820s.dts
@@ -160,7 +160,7 @@
 	mac-address-increment = <1>;
 };
 
-&ethphy0 {
+&ethphy4 {
 	/delete-property/ interrupts;
 };
 


### PR DESCRIPTION
The dts of ZTE E8820s has an error configuration of ethphy4 which leads to WAN interface misfunction.

After referenced the similar routers' dts, I found the mt7621_zte_e8820s.dts has mistaked disabled ethphy0's interrupts:

```
&ethphy0 {
	/delete-property/ interrupts;
};
```
While the wan interface which connect to CPU directly is ethphy4, after change to disable ethphy4's interrupts, I got wan resumed.